### PR TITLE
chore: migrate to hardened Deno 2 images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,12 @@ services:
             - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672
             - KILLBILL_BASE_URL=http://killbill:8080
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8001"]
+            test: [
+                "CMD",
+                "deno",
+                "eval",
+                "const r = await fetch('http://localhost:8001'); if(!r.ok) Deno.exit(1);",
+            ]
             interval: 15s
             timeout: 5s
             retries: 5
@@ -159,7 +164,12 @@ services:
             - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672
             - KILLBILL_BASE_URL=http://killbill:8080
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8003"]
+            test: [
+                "CMD",
+                "deno",
+                "eval",
+                "const r = await fetch('http://localhost:8003'); if(!r.ok) Deno.exit(1);",
+            ]
             interval: 15s
             timeout: 5s
             retries: 5
@@ -189,7 +199,12 @@ services:
             - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672
             - KILLBILL_BASE_URL=http://killbill:8080
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8002"]
+            test: [
+                "CMD",
+                "deno",
+                "eval",
+                "const r = await fetch('http://localhost:8002'); if(!r.ok) Deno.exit(1);",
+            ]
             interval: 15s
             timeout: 5s
             retries: 5

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM dhi.io/deno:2
 
-# Install curl for health check
-# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 # Copy workspace configuration

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -2,10 +2,10 @@
 # Deno-based microservice that handles Kill Bill account creation
 # and publishes account.ready events via RabbitMQ
 
-FROM denoland/deno:debian
+FROM dhi.io/deno:2
 
 # Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,15 +19,13 @@ COPY supabase/functions/_shared ./supabase/functions/_shared
 COPY services/account-service ./services/account-service
 
 # Cache dependencies
-RUN deno cache \
-    --config=deno.json \
-    services/account-service/index.ts
+RUN ["deno", "cache", "--config=deno.json", "services/account-service/index.ts"]
 
 # Expose health check port
 EXPOSE 8001
 
-# Health check: account-service serves status JSON on port 8001
+# Health check using deno eval (distroless image, no curl/sh available)
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8001 || exit 1
+    CMD ["deno", "eval", "const r = await fetch('http://localhost:8001'); if(!r.ok) Deno.exit(1);"]
 
-CMD ["deno", "run", "--allow-all", "--config=deno.json", "services/account-service/index.ts"]
+CMD ["run", "--allow-all", "--config=deno.json", "services/account-service/index.ts"]

--- a/services/invoice-service/Dockerfile
+++ b/services/invoice-service/Dockerfile
@@ -2,10 +2,10 @@
 # Deno-based microservice that handles Kill Bill invoice generation
 # and publishes invoice.generated events via RabbitMQ
 
-FROM denoland/deno:debian
+FROM dhi.io/deno:2
 
 # Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,15 +19,13 @@ COPY supabase/functions/_shared ./supabase/functions/_shared
 COPY services/invoice-service ./services/invoice-service
 
 # Cache dependencies
-RUN deno cache \
-    --config=deno.json \
-    services/invoice-service/index.ts
+RUN ["deno", "cache", "--config=deno.json", "services/invoice-service/index.ts"]
 
 # Expose health check port
 EXPOSE 8002
 
-# Health check: invoice-service serves status JSON on port 8002
+# Health check using deno eval (distroless image, no curl/sh available)
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8002 || exit 1
+    CMD ["deno", "eval", "const r = await fetch('http://localhost:8002'); if(!r.ok) Deno.exit(1);"]
 
-CMD ["deno", "run", "--allow-all", "--config=deno.json", "services/invoice-service/index.ts"]
+CMD ["run", "--allow-all", "--config=deno.json", "services/invoice-service/index.ts"]

--- a/services/invoice-service/Dockerfile
+++ b/services/invoice-service/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM dhi.io/deno:2
 
-# Install curl for health check
-# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 # Copy workspace configuration

--- a/services/subscription-service/Dockerfile
+++ b/services/subscription-service/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM dhi.io/deno:2
 
-# Install curl for health check
-# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 # Copy workspace configuration

--- a/services/subscription-service/Dockerfile
+++ b/services/subscription-service/Dockerfile
@@ -2,10 +2,10 @@
 # Deno-based microservice that handles Kill Bill subscription creation
 # and orchestrates the subscription SAGA workflow via RabbitMQ
 
-FROM denoland/deno:debian
+FROM dhi.io/deno:2
 
 # Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,15 +19,13 @@ COPY supabase/functions/_shared ./supabase/functions/_shared
 COPY services/subscription-service ./services/subscription-service
 
 # Cache dependencies
-RUN deno cache \
-    --config=deno.json \
-    services/subscription-service/index.ts
+RUN ["deno", "cache", "--config=deno.json", "services/subscription-service/index.ts"]
 
 # Expose health check port
 EXPOSE 8003
 
-# Health check: subscription-service serves status JSON on port 8003
+# Health check using deno eval (distroless image, no curl/sh available)
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8003 || exit 1
+    CMD ["deno", "eval", "const r = await fetch('http://localhost:8003'); if(!r.ok) Deno.exit(1);"]
 
-CMD ["deno", "run", "--allow-all", "--config=deno.json", "services/subscription-service/index.ts"]
+CMD ["run", "--allow-all", "--config=deno.json", "services/subscription-service/index.ts"]


### PR DESCRIPTION
This pull request updates the Dockerfiles and `docker-compose.yml` configuration for the Deno-based microservices to use a distroless Deno image and switches all health checks from using `curl` to using `deno eval` with a fetch request. This improves container security and reduces dependencies by eliminating the need for a shell and `curl` in the images.

Key changes:

**Docker image and health check improvements:**

* Switched the base image in all service Dockerfiles from `denoland/deno:debian` to the distroless `dhi.io/deno:2`, which does not include a shell or `curl`. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL5-R8) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L5-R8) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L5-R8)
* Updated health checks in all service Dockerfiles to use `deno eval` with a fetch request instead of `curl`, ensuring compatibility with the distroless image. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL22-R31) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L22-R31) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L22-R31)

**Docker Compose configuration updates:**

* Modified the `healthcheck` commands for all relevant services in `docker-compose.yml` to use `deno eval` instead of `curl`, matching the new Dockerfile approach. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L132-R137) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L162-R172) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L192-R207)

**Build and run command adjustments:**

* Changed the dependency caching and run commands in all Dockerfiles to use JSON array syntax for `RUN` and `CMD`, improving clarity and compatibility. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL22-R31) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L22-R31) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L22-R31)

These changes make the service containers smaller, more secure, and easier to maintain by removing unnecessary OS-level tools and aligning health checks with the new base image.