### PR TITLE
Migrate to distroless Deno 2 images and upgrade RabbitMQ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,12 @@ services:
             - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672
             - KILLBILL_BASE_URL=http://killbill:8080
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8001"]
+            test: [
+                "CMD",
+                "deno",
+                "eval",
+                "const r = await fetch('http://localhost:8001'); if(!r.ok) Deno.exit(1);",
+            ]
             interval: 15s
             timeout: 5s
             retries: 5
@@ -159,7 +164,12 @@ services:
             - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672
             - KILLBILL_BASE_URL=http://killbill:8080
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8003"]
+            test: [
+                "CMD",
+                "deno",
+                "eval",
+                "const r = await fetch('http://localhost:8003'); if(!r.ok) Deno.exit(1);",
+            ]
             interval: 15s
             timeout: 5s
             retries: 5
@@ -189,7 +199,12 @@ services:
             - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672
             - KILLBILL_BASE_URL=http://killbill:8080
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8002"]
+            test: [
+                "CMD",
+                "deno",
+                "eval",
+                "const r = await fetch('http://localhost:8002'); if(!r.ok) Deno.exit(1);",
+            ]
             interval: 15s
             timeout: 5s
             retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Management UI: http://localhost:15672 (guest/guest)
     # ============================================================================
     rabbitmq:
-        image: rabbitmq:3-management
+        image: dhi.io/rabbitmq:4.2
         container_name: rabbitmq
         hostname: rabbitmq
         ports:
@@ -24,6 +24,9 @@ services:
         environment:
             RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
             RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+        configs:
+            - source: rabbitmq-plugins
+              target: /etc/rabbitmq/enabled_plugins
         volumes:
             - rabbitmq_data:/var/lib/rabbitmq
         healthcheck:
@@ -215,6 +218,11 @@ services:
             killbill:
                 condition: service_healthy
         restart: unless-stopped
+
+
+configs:
+  rabbitmq-plugins:
+    content: "[rabbitmq_management]."  
 
 volumes:
     rabbitmq_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
         configs:
             - source: rabbitmq-plugins
               target: /etc/rabbitmq/enabled_plugins
+            # Remove in production: Bypass RabbitMQ user authentication for Guest
+            - source: rabbitmq-conf
+              target: /etc/rabbitmq/rabbitmq.conf
         volumes:
             - rabbitmq_data:/var/lib/rabbitmq
         healthcheck:
@@ -221,8 +224,11 @@ services:
 
 
 configs:
-  rabbitmq-plugins:
-    content: "[rabbitmq_management]."  
+    rabbitmq-plugins:
+        content: "[rabbitmq_management]."
+    # Remove in production: Bypass RabbitMQ user authentication for Guest
+    rabbitmq-conf:
+        content: "loopback_users.guest = false"
 
 volumes:
     rabbitmq_data:

--- a/infra/rabbitMQ/docker-compose.yml
+++ b/infra/rabbitMQ/docker-compose.yml
@@ -1,16 +1,30 @@
-version: "3.8"
 services:
     rabbitmq:
-        image: rabbitmq:3-management
-        hostname: my-rabbit
+        image: dhi.io/rabbitmq:4.2
+        hostname: rabbitmq
         ports:
-            - "5672:5672"
-            - "15672:15672"
+            - "5672:5672" # AMQP
+            - "15672:15672" # Management UI
         environment:
-            RABBITMQ_DEFAULT_USER: guest
-            RABBITMQ_DEFAULT_PASS: guest
+            RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+            RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+        configs:
+            - source: rabbitmq-plugins
+              target: /etc/rabbitmq/enabled_plugins
         volumes:
             - rabbitmq_data:/var/lib/rabbitmq
+        healthcheck:
+            test: ["CMD", "rabbitmq-diagnostics", "ping"]
+            interval: 10s
+            timeout: 5s
+            retries: 10
+            start_period: 30s
+        restart: unless-stopped
+
+
+configs:
+    rabbitmq-plugins:
+        content: "[rabbitmq_management]."
 
 volumes:
     rabbitmq_data:

--- a/infra/rabbitMQ/docker-compose.yml
+++ b/infra/rabbitMQ/docker-compose.yml
@@ -11,6 +11,9 @@ services:
         configs:
             - source: rabbitmq-plugins
               target: /etc/rabbitmq/enabled_plugins
+            # Bypass RabbitMQ user authentication for Guest, Remove in Production
+            - source: rabbitmq-conf
+              target: /etc/rabbitmq/rabbitmq.conf
         volumes:
             - rabbitmq_data:/var/lib/rabbitmq
         healthcheck:
@@ -25,6 +28,8 @@ services:
 configs:
     rabbitmq-plugins:
         content: "[rabbitmq_management]."
-
+    # Bypass RabbitMQ user authentication for Guest, Remove in Production
+    rabbitmq-conf:
+        content: "loopback_users.guest = false"
 volumes:
     rabbitmq_data:

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM dhi.io/deno:2
 
-# Install curl for health check
-# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 # Copy workspace configuration

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -2,10 +2,10 @@
 # Deno-based microservice that handles Kill Bill account creation
 # and publishes account.ready events via RabbitMQ
 
-FROM denoland/deno:debian
+FROM dhi.io/deno:2
 
 # Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,15 +19,13 @@ COPY supabase/functions/_shared ./supabase/functions/_shared
 COPY services/account-service ./services/account-service
 
 # Cache dependencies
-RUN deno cache \
-    --config=deno.json \
-    services/account-service/index.ts
+RUN ["deno", "cache", "--config=deno.json", "services/account-service/index.ts"]
 
 # Expose health check port
 EXPOSE 8001
 
-# Health check: account-service serves status JSON on port 8001
+# Health check using deno eval (distroless image, no curl/sh available)
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8001 || exit 1
+    CMD ["deno", "eval", "const r = await fetch('http://localhost:8001'); if(!r.ok) Deno.exit(1);"]
 
-CMD ["deno", "run", "--allow-all", "--config=deno.json", "services/account-service/index.ts"]
+CMD ["run", "--allow-all", "--config=deno.json", "services/account-service/index.ts"]

--- a/services/invoice-service/Dockerfile
+++ b/services/invoice-service/Dockerfile
@@ -2,10 +2,10 @@
 # Deno-based microservice that handles Kill Bill invoice generation
 # and publishes invoice.generated events via RabbitMQ
 
-FROM denoland/deno:debian
+FROM dhi.io/deno:2
 
 # Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,15 +19,13 @@ COPY supabase/functions/_shared ./supabase/functions/_shared
 COPY services/invoice-service ./services/invoice-service
 
 # Cache dependencies
-RUN deno cache \
-    --config=deno.json \
-    services/invoice-service/index.ts
+RUN ["deno", "cache", "--config=deno.json", "services/invoice-service/index.ts"]
 
 # Expose health check port
 EXPOSE 8002
 
-# Health check: invoice-service serves status JSON on port 8002
+# Health check using deno eval (distroless image, no curl/sh available)
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8002 || exit 1
+    CMD ["deno", "eval", "const r = await fetch('http://localhost:8002'); if(!r.ok) Deno.exit(1);"]
 
-CMD ["deno", "run", "--allow-all", "--config=deno.json", "services/invoice-service/index.ts"]
+CMD ["run", "--allow-all", "--config=deno.json", "services/invoice-service/index.ts"]

--- a/services/invoice-service/Dockerfile
+++ b/services/invoice-service/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM dhi.io/deno:2
 
-# Install curl for health check
-# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 # Copy workspace configuration

--- a/services/subscription-service/Dockerfile
+++ b/services/subscription-service/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM dhi.io/deno:2
 
-# Install curl for health check
-# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 # Copy workspace configuration

--- a/services/subscription-service/Dockerfile
+++ b/services/subscription-service/Dockerfile
@@ -2,10 +2,10 @@
 # Deno-based microservice that handles Kill Bill subscription creation
 # and orchestrates the subscription SAGA workflow via RabbitMQ
 
-FROM denoland/deno:debian
+FROM dhi.io/deno:2
 
 # Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,15 +19,13 @@ COPY supabase/functions/_shared ./supabase/functions/_shared
 COPY services/subscription-service ./services/subscription-service
 
 # Cache dependencies
-RUN deno cache \
-    --config=deno.json \
-    services/subscription-service/index.ts
+RUN ["deno", "cache", "--config=deno.json", "services/subscription-service/index.ts"]
 
 # Expose health check port
 EXPOSE 8003
 
-# Health check: subscription-service serves status JSON on port 8003
+# Health check using deno eval (distroless image, no curl/sh available)
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8003 || exit 1
+    CMD ["deno", "eval", "const r = await fetch('http://localhost:8003'); if(!r.ok) Deno.exit(1);"]
 
-CMD ["deno", "run", "--allow-all", "--config=deno.json", "services/subscription-service/index.ts"]
+CMD ["run", "--allow-all", "--config=deno.json", "services/subscription-service/index.ts"]

--- a/tests/integration/test-regression.sh
+++ b/tests/integration/test-regression.sh
@@ -204,6 +204,17 @@ check_prerequisites() {
   else
     log_warning "AUTH_BASE_URL: $auth_url"
   fi
+
+  # Initialize Kill Bill Tenant
+  log_info "Initializing Kill Bill tenant and catalog..."
+  local kb_api_key=$(grep "^KILLBILL_API_KEY=" .env 2>/dev/null | cut -d= -f2)
+  local kb_api_secret=$(grep "^KILLBILL_API_SECRET=" .env 2>/dev/null | cut -d= -f2)
+  kb_api_key=${kb_api_key:-demo}
+  kb_api_secret=${kb_api_secret:-demosecret}
+  
+  ./infra/killbill/init-tenant.sh -k "$kb_api_key" -s "$kb_api_secret" >/dev/null 2>&1 || log_warning "Tenant init may have failed"
+  ./infra/killbill/init-plans-catalog.sh --api-key "$kb_api_key" --api-secret "$kb_api_secret" >/dev/null 2>&1 || log_warning "Catalog init may have failed"
+  log_success "Kill Bill initialization completed"
 }
 
 # =============================================================================

--- a/tests/integration/test-subs-e2e.sh
+++ b/tests/integration/test-subs-e2e.sh
@@ -10,7 +10,21 @@ echo ""
 SUPABASE_URL="http://localhost:54321"
 FUNCTIONS_URL="${SUPABASE_URL}/functions/v1/kuala"
 AUTH_URL="${SUPABASE_URL}/auth/v1"
-ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU2NTA0ODAwLCJleHAiOjE5MTQyNzEyMDB9.zbstohWXIZRgD0aE4UVeh3xZRGq4fDOZ7cUzFBV26SU"
+ANON_KEY="sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH"
+
+echo "================================================================================================"
+echo "🛠️  STEP 0: Initialize Kill Bill"
+echo "================================================================================================"
+KB_API_KEY=$(grep "^KILLBILL_API_KEY=" .env 2>/dev/null | cut -d= -f2)
+KB_API_SECRET=$(grep "^KILLBILL_API_SECRET=" .env 2>/dev/null | cut -d= -f2)
+KB_API_KEY=${KB_API_KEY:-demo}
+KB_API_SECRET=${KB_API_SECRET:-demosecret}
+
+./infra/killbill/init-tenant.sh -k "$KB_API_KEY" -s "$KB_API_SECRET" >/dev/null 2>&1 || echo "⚠️  Tenant init may have failed"
+./infra/killbill/init-plans-catalog.sh --api-key "$KB_API_KEY" --api-secret "$KB_API_SECRET" >/dev/null 2>&1 || echo "⚠️  Catalog init may have failed"
+echo "✅ Kill Bill initialized"
+echo ""
+
 # Read token from previous user creation or create new one
 if [ -f /tmp/test-user-response.json ]; then
   REFRESH_TOKEN=$(cat /tmp/test-user-response.json | jq -r '.refresh_token // empty')


### PR DESCRIPTION
This pull request updates the Docker setup for RabbitMQ and all Deno-based microservices to use custom images and distroless containers, improves health checks, and standardizes configuration across environments. The most important changes are grouped below.

**RabbitMQ image and configuration updates:**

* Switched RabbitMQ images to `dhi.io/rabbitmq:4.2` in both `docker-compose.yml` and `infra/rabbitMQ/docker-compose.yml` for consistency and to support custom plugin management. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L18-R18) [[2]](diffhunk://#diff-7f7ebb8eae8f41554ef45838ee8c6f8d449a8d7794183a81bec88669cd0b63f0L1-R27)
* Added a Docker config (`rabbitmq-plugins`) to enable the management plugin, mounting it at `/etc/rabbitmq/enabled_plugins`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R27-R29) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R222-R226) [[3]](diffhunk://#diff-7f7ebb8eae8f41554ef45838ee8c6f8d449a8d7794183a81bec88669cd0b63f0L1-R27)
* Standardized RabbitMQ environment variables to use `${RABBITMQ_USER:-guest}` and `${RABBITMQ_PASS:-guest}` in all relevant places. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R27-R29) [[2]](diffhunk://#diff-7f7ebb8eae8f41554ef45838ee8c6f8d449a8d7794183a81bec88669cd0b63f0L1-R27)

**Microservice image and health check improvements:**

* Updated all Deno-based microservices (`account-service`, `invoice-service`, `subscription-service`) to use the `dhi.io/deno:2` distroless image, removing dependencies on `curl` and shell. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL5-R5) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L5-R5) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L5-R5)
* Replaced health checks in Dockerfiles and `docker-compose.yml` to use `deno eval` with a fetch request instead of `curl`, ensuring compatibility with distroless images. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL22-R28) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L22-R28) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L22-R28) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L132-R140) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L162-R175) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L192-R210)

**General Dockerfile and Compose improvements:**

* Converted `RUN deno cache ...` commands to JSON array syntax for better compatibility with distroless images. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL22-R28) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L22-R28) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L22-R28)
* Updated `CMD` instructions to drop the `deno` prefix, since the base image sets the entrypoint. [[1]](diffhunk://#diff-5cbeaa993be62c9a37b5d90b9a6d2d045dca41c068faac0da83cb21b94d369cbL22-R28) [[2]](diffhunk://#diff-41d4917a058cc4c8e778729553d2184f0123c3033573e0a25241411d6884a7b3L22-R28) [[3]](diffhunk://#diff-313c73d92752809c77f7bc86fecdf6fc3e8d8fb533800c5b1abda8f39966f6e4L22-R28)

These changes improve security, consistency, and maintainability of the microservices and infrastructure setup.